### PR TITLE
Update NGINX_AUTH_BASE_URL to use local docker name

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -9,7 +9,7 @@ services:
       - VIRTUAL_HOST=alpha-cm.dina-web.net
       - VIRTUAL_PROTO=http
       - VIRTUAL_PORT=8000
-      - NGINX_AUTH_BASE_URL=https://alpha-keycloak.dina-web.net
+      - NGINX_AUTH_BASE_URL=http://keycloak:8080
       - NGINX_HOST=alpha-cm.dina-web.net
       - NGINX_PORT=8000
     command: /bin/bash -c "envsubst '$$NGINX_HOST $$NGINX_PORT $$NGINX_AUTH_BASE_URL' < /etc/nginx/conf.d/default.template > /etc/nginx/conf.d/default.conf && nginx -g 'daemon off;'"
@@ -22,7 +22,7 @@ services:
       - VIRTUAL_HOST=alpha-cm-mock.dina-web.net
       - VIRTUAL_PROTO=http
       - VIRTUAL_PORT=8001
-      - NGINX_AUTH_BASE_URL=https://alpha-keycloak.dina-web.net
+      - NGINX_AUTH_BASE_URL=http://keycloak:8080
       - NGINX_HOST=alpha-cm-mock.dina-web.net
       - NGINX_PORT=8001
     command: /bin/bash -c "envsubst '$$NGINX_HOST $$NGINX_PORT $$NGINX_AUTH_BASE_URL' < /etc/nginx/conf.d/default.template > /etc/nginx/conf.d/default.conf && nginx -g 'daemon off;'"


### PR DESCRIPTION
From https://alpha-keycloak.dina-web.net -> http://keycloak:8080. Only
in the production setup since in demoed we want to work towards the
test -server and need the full domain name